### PR TITLE
fix: StickyTitle 和 ItemView 重叠显示的问题

### DIFF
--- a/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
+++ b/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
@@ -335,7 +335,9 @@ public class IndexableLayout extends FrameLayout {
                 if (mStickyViewHolder != null && list.size() > firstItemPosition) {
                     EntityWrapper wrapper = list.get(firstItemPosition);
                     String wrapperTitle = wrapper.getIndexTitle();
-
+                    if (EntityWrapper.TYPE_TITLE == wrapper.getItemType()) {
+                        mLayoutManager.findViewByPosition(firstItemPosition).setVisibility(INVISIBLE);
+                    }
                     // hide -> show
                     if (wrapperTitle == null && mStickyViewHolder.itemView.getVisibility() == VISIBLE) {
                         mStickyTitle = null;
@@ -350,6 +352,9 @@ public class IndexableLayout extends FrameLayout {
                         if (nextWrapper.getItemType() == EntityWrapper.TYPE_TITLE) {
                             if (nextTitleView.getTop() <= mStickyViewHolder.itemView.getHeight() && wrapperTitle != null) {
                                 mStickyViewHolder.itemView.setTranslationY(nextTitleView.getTop() - mStickyViewHolder.itemView.getHeight());
+                            }
+                            if (INVISIBLE == nextTitleView.getVisibility()) {
+                                nextTitleView.setVisibility(VISIBLE);
                             }
                         } else if (mStickyViewHolder.itemView.getTranslationY() != 0) {
                             mStickyViewHolder.itemView.setTranslationY(0);


### PR DESCRIPTION
- 向上滑动的时候，new title 把 old title顶上去的一瞬间，RecyclerView中的ItemView和StickyTitle重叠显示，继续向上滑动，可以明显的看到两个Titie重叠显示。