### PR TITLE
修复TitleView重叠问题，避免View复用引起的TitleView丢失问题

### DIFF
--- a/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
+++ b/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
@@ -63,6 +63,7 @@ public class IndexableLayout extends FrameLayout {
 
     private RecyclerView mRecy;
     private IndexBar mIndexBar;
+    private View mLastInvisibleRecyclerViewItemView;
 
     private boolean mSticyEnable = true;
     private RecyclerView.ViewHolder mStickyViewHolder;
@@ -374,13 +375,17 @@ public class IndexableLayout extends FrameLayout {
                     EntityWrapper wrapper = list.get(firstItemPosition);
                     String wrapperTitle = wrapper.getIndexTitle();
 
-//                    if (EntityWrapper.TYPE_TITLE == wrapper.getItemType()) {
-//                        if (mLinearLayoutManager != null) {
-//                            mLinearLayoutManager.findViewByPosition(firstItemPosition).setVisibility(INVISIBLE);
-//                        } else if (mGridLayoutManager != null) {
-//                            mGridLayoutManager.findViewByPosition(firstItemPosition).setVisibility(INVISIBLE);
-//                        }
-//                    }
+                    if (EntityWrapper.TYPE_TITLE == wrapper.getItemType()) {
+                        if (mLinearLayoutManager != null) {
+                            if (mLastInvisibleRecyclerViewItemView != null) {
+                                mLastInvisibleRecyclerViewItemView.setVisibility(VISIBLE);
+                            }
+                            mLastInvisibleRecyclerViewItemView = mLinearLayoutManager.findViewByPosition(firstItemPosition);
+                            mLastInvisibleRecyclerViewItemView.setVisibility(INVISIBLE);
+                        } else if (mGridLayoutManager != null) {
+                            mGridLayoutManager.findViewByPosition(firstItemPosition).setVisibility(INVISIBLE);
+                        }
+                    }
 
                     // hide -> show
                     if (wrapperTitle == null && mStickyViewHolder.itemView.getVisibility() == VISIBLE) {
@@ -399,15 +404,13 @@ public class IndexableLayout extends FrameLayout {
                                 if (nextTitleView.getTop() <= mStickyViewHolder.itemView.getHeight() && wrapperTitle != null) {
                                     mStickyViewHolder.itemView.setTranslationY(nextTitleView.getTop() - mStickyViewHolder.itemView.getHeight());
                                 }
+                                if (INVISIBLE == nextTitleView.getVisibility()) {
+                                    nextTitleView.setVisibility(VISIBLE);
+                                }
                             } else if (mStickyViewHolder.itemView.getTranslationY() != 0) {
                                 mStickyViewHolder.itemView.setTranslationY(0);
                             }
                         }
-
-//                        View nextTitleView = mLinearLayoutManager.findViewByPosition(firstItemPosition);
-//                        if (INVISIBLE == nextTitleView.getVisibility()) {
-//                            nextTitleView.setVisibility(VISIBLE);
-//                        }
                     }
 
                     // GirdLayoutManager

--- a/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
+++ b/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
@@ -63,6 +63,13 @@ public class IndexableLayout extends FrameLayout {
 
     private RecyclerView mRecy;
     private IndexBar mIndexBar;
+    /**
+     * 保存正在Invisible的ItemView
+     * <p>
+     * 使用mLastInvisibleRecyclerViewItemView来保存当前Invisible的ItemView，
+     * 每次有新的ItemView需要Invisible的时候，把旧的Invisible的ItemView设为Visible。
+     * 这样就修复了View复用导致的Invisible状态传递的问题。
+     */
     private View mLastInvisibleRecyclerViewItemView;
 
     private boolean mSticyEnable = true;
@@ -405,6 +412,8 @@ public class IndexableLayout extends FrameLayout {
                                     mStickyViewHolder.itemView.setTranslationY(nextTitleView.getTop() - mStickyViewHolder.itemView.getHeight());
                                 }
                                 if (INVISIBLE == nextTitleView.getVisibility()) {
+                                    //特殊情况：手指向下滑动的时候，需要及时把成为第二个可见View的TitleView设置Visible，
+                                    // 这样才能配合StickyView制造两个TitleView切换的动画。
                                     nextTitleView.setVisibility(VISIBLE);
                                 }
                             } else if (mStickyViewHolder.itemView.getTranslationY() != 0) {

--- a/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
+++ b/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/IndexableLayout.java
@@ -383,14 +383,17 @@ public class IndexableLayout extends FrameLayout {
                     String wrapperTitle = wrapper.getIndexTitle();
 
                     if (EntityWrapper.TYPE_TITLE == wrapper.getItemType()) {
+                        if (mLastInvisibleRecyclerViewItemView != null && mLastInvisibleRecyclerViewItemView.getVisibility() == INVISIBLE) {
+                            mLastInvisibleRecyclerViewItemView.setVisibility(VISIBLE);
+                            mLastInvisibleRecyclerViewItemView = null;
+                        }
                         if (mLinearLayoutManager != null) {
-                            if (mLastInvisibleRecyclerViewItemView != null) {
-                                mLastInvisibleRecyclerViewItemView.setVisibility(VISIBLE);
-                            }
                             mLastInvisibleRecyclerViewItemView = mLinearLayoutManager.findViewByPosition(firstItemPosition);
-                            mLastInvisibleRecyclerViewItemView.setVisibility(INVISIBLE);
                         } else if (mGridLayoutManager != null) {
-                            mGridLayoutManager.findViewByPosition(firstItemPosition).setVisibility(INVISIBLE);
+                            mLastInvisibleRecyclerViewItemView = mGridLayoutManager.findViewByPosition(firstItemPosition);
+                        }
+                        if (mLastInvisibleRecyclerViewItemView != null) {
+                            mLastInvisibleRecyclerViewItemView.setVisibility(INVISIBLE);
                         }
                     }
 
@@ -432,23 +435,16 @@ public class IndexableLayout extends FrameLayout {
                                     if (nextTitleView.getTop() <= mStickyViewHolder.itemView.getHeight() && wrapperTitle != null) {
                                         mStickyViewHolder.itemView.setTranslationY(nextTitleView.getTop() - mStickyViewHolder.itemView.getHeight());
                                     }
+                                    if (INVISIBLE == nextTitleView.getVisibility()) {
+                                        //特殊情况：手指向下滑动的时候，需要及时把成为第二个可见View的TitleView设置Visible，
+                                        // 这样才能配合StickyView制造两个TitleView切换的动画。
+                                        nextTitleView.setVisibility(VISIBLE);
+                                    }
                                     break;
                                 } else if (mStickyViewHolder.itemView.getTranslationY() != 0) {
                                     mStickyViewHolder.itemView.setTranslationY(0);
                                 }
                             }
-
-                            // 注意与上边的for循环，起点不同
-//                            for (int i = firstItemPosition; i <= firstItemPosition + mGridLayoutManager.getSpanCount(); i++) {
-//                                EntityWrapper nextWrapper = list.get(i);
-//                                View nextTitleView = mGridLayoutManager.findViewByPosition(i);
-//                                if (nextWrapper.getItemType() == EntityWrapper.TYPE_TITLE) {
-//                                    if (INVISIBLE == nextTitleView.getVisibility()) {
-//                                        nextTitleView.setVisibility(VISIBLE);
-//                                    }
-//                                }
-//                            }
-
                         }
                     } // end GridLayoutManager
                 }


### PR DESCRIPTION
 - 同一时间段只有一个Title是不可见的。第一个可见View是TitleView的时候设置其为Invisible，防止重叠。
- 使用mLastInvisibleRecyclerViewItemView来保存当前Invisible的ItemView，每次有新的ItemView需要Invisible的时候，把旧的Ible。这样就修复了View复用导致的Invisible状态传递的问题。
- 特殊情况：手指向下滑动的时候，需要及时把成为第二个可见View的TitleView设置Visible，这样才能配合StickyView制造两个TitleView切换的动画。