### PR TITLE
fix: 修复分组过长时下面的TitleView依然Invisible的情况

### DIFF
--- a/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/RealAdapter.java
+++ b/indexablerecyclerview/src/main/java/me/yokeyword/indexablerv/RealAdapter.java
@@ -175,6 +175,9 @@ class RealAdapter<T extends IndexableEntity> extends RecyclerView.Adapter<Recycl
 
         int viewType = getItemViewType(position);
         if (viewType == EntityWrapper.TYPE_TITLE) {
+            if (View.INVISIBLE == holder.itemView.getVisibility()) {
+                holder.itemView.setVisibility(View.VISIBLE);
+            }
             mAdapter.onBindTitleViewHolder(holder, item.getIndexTitle());
         } else if (viewType == EntityWrapper.TYPE_CONTENT) {
             mAdapter.onBindContentViewHolder(holder, item.getData());


### PR DESCRIPTION
正常滑动页面的时候，如果一个分组中Item数量比较大，就会导致第二个TitleView不能及时Invisible，此时无法触发使得复用的TitleView Visible。所以在RealAdapter中onBindViewHolder的时候判断如果TitleView是Invisible的情况，就把它设为Visible。